### PR TITLE
fix wrong home directory

### DIFF
--- a/winstrap.go
+++ b/winstrap.go
@@ -214,7 +214,7 @@ func check(err error) {
 	}
 }
 
-func home() string { return os.Getenv("HOMEPATH") }
+func home() string { return os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH") }
 
 func goroot() string { return filepath.Join(home(), "goroot") }
 


### PR DESCRIPTION
On Windows $HOME is defined as combination of
%HOMEDRIVE% and %HOMEPATH%.

Signed-off-by: Jens Frederich jfrederich@gmail.com
